### PR TITLE
Fix hyperbunTableForType for pointer types

### DIFF
--- a/hyperbun.go
+++ b/hyperbun.go
@@ -433,6 +433,10 @@ func annotate(err error, op string, kvs ...interface{}) error {
 func hyperbunTableForType[T any]() string {
 	var t T
 	typ := reflect.TypeOf(t)
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
 		val, ok := f.Tag.Lookup("bun")

--- a/hyperbun_test.go
+++ b/hyperbun_test.go
@@ -18,6 +18,10 @@ func TestHyperbunTableForType(t *testing.T) {
 	assert.Equal(t, "test_struct", hyperbunTableForType[testStruct]())
 }
 
+func TestHyperbunTableForPtrType(t *testing.T) {
+	assert.Equal(t, "test_struct", hyperbunTableForType[*testStruct]())
+}
+
 func TestAnnotateEven(t *testing.T) {
 	assert.Equal(t,
 		"performing TestAnnotate hello='world' id='0': test_error",


### PR DESCRIPTION
This fixes https://github.com/Hypersequent/tms-issues/issues/498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved type handling in the `hyperbunTableForType` function to correctly process pointer types.

- **Tests**
	- Added a new test to verify the handling of pointer types in the `hyperbunTableForType` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->