### PR TITLE
Fix hyperbunTableForType for pointer types (2)

### DIFF
--- a/hyperbun.go
+++ b/hyperbun.go
@@ -433,8 +433,12 @@ func annotate(err error, op string, kvs ...interface{}) error {
 func hyperbunTableForType[T any]() string {
 	var t T
 	typ := reflect.TypeOf(t)
-	if typ.Kind() == reflect.Pointer {
+	kind := typ.Kind()
+
+	// This covers the case like *U, []U, *[]U, []*U etc
+	for kind == reflect.Pointer || kind == reflect.Slice {
 		typ = typ.Elem()
+		kind = typ.Kind()
 	}
 
 	for i := 0; i < typ.NumField(); i++ {

--- a/hyperbun_test.go
+++ b/hyperbun_test.go
@@ -16,10 +16,10 @@ type testStruct struct {
 
 func TestHyperbunTableForType(t *testing.T) {
 	assert.Equal(t, "test_struct", hyperbunTableForType[testStruct]())
-}
-
-func TestHyperbunTableForPtrType(t *testing.T) {
 	assert.Equal(t, "test_struct", hyperbunTableForType[*testStruct]())
+	assert.Equal(t, "test_struct", hyperbunTableForType[[]testStruct]())
+	assert.Equal(t, "test_struct", hyperbunTableForType[[]*testStruct]())
+	assert.Equal(t, "test_struct", hyperbunTableForType[*[]testStruct]())
 }
 
 func TestAnnotateEven(t *testing.T) {


### PR DESCRIPTION
In addition to pointers, hyperbunTableForType can also be called slices, pointer to slices, slice of pointers etc. This fix handles all those scenarios too

This is an additional fix for https://github.com/Hypersequent/tms-issues/issues/498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of various data types (including pointers and slices) in the type processing logic.

- **Tests**
  - Enhanced test coverage for different data types including slices and pointers.
  - Removed redundant tests to streamline testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->