### PR TITLE
Avoid savepoints when calling RunInTx from TxContext

### DIFF
--- a/hyperbun.go
+++ b/hyperbun.go
@@ -126,9 +126,7 @@ func (m TxContext) NewValues(model interface{}) *bun.ValuesQuery {
 }
 
 func (m TxContext) RunInTx(fn func(tx TxContext) error) error {
-	return m.Bun.RunInTx(m.ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
-		return fn(NewTxContext(ctx, tx))
-	})
+	return fn(m)
 }
 
 func ByID[T any, ID string | int](m DB, id ID) (*T, error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified transaction management by directly utilizing the existing `TxContext` in the `RunInTx` method, potentially improving performance and reducing complexity in transaction handling.

- **Bug Fixes**
	- Addressed control flow issues related to nested transactions, enhancing overall application logic around transaction management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->